### PR TITLE
Color Palette & Typography Adjustments for Cupertino widgets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "7.4.2"
 kotlin = "1.8.20"
 compose-compiler = "1.4.6"
-compose = "1.4.0"
+compose = "1.5.0-dev1071"
 androidx-appcompat = "1.6.1"
 activity-compose = "1.7.0"
 

--- a/lookandfeel/src/androidMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoDialogs.android.kt
+++ b/lookandfeel/src/androidMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoDialogs.android.kt
@@ -2,7 +2,6 @@ package com.github.alexzhirkevich.lookandfeel.components.cupertino
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
@@ -10,7 +9,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.github.alexzhirkevich.lookandfeel.theme.AdaptiveTheme
 
 @Composable
@@ -48,7 +46,7 @@ actual fun CupertinoAlertDialogNative(
         title = { Text(title.orEmpty()) },
         message = { Text(message.orEmpty()) },
         containerColor = if (containerColor.isSpecified)
-            containerColor else AdaptiveTheme.colorScheme.surface,
+            containerColor else AdaptiveTheme.colorScheme.tertiaryContainer,
         buttons = {
             fromNative(buttons)
         },

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoDialogs.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoDialogs.kt
@@ -2,15 +2,11 @@
 
 package com.github.alexzhirkevich.lookandfeel.components.cupertino
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
@@ -27,9 +23,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BackdropScaffoldDefaults
 import androidx.compose.material.BackdropScaffoldState
 import androidx.compose.material.BackdropValue
@@ -46,7 +40,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -140,12 +133,12 @@ interface CupertinoNativeAlertDialogButtonsScope {
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun CupertinoAlertDialog(
-    onDismissRequest : () -> Unit,
-    title : @Composable () -> Unit,
-    message : (@Composable () -> Unit)? = null,
-    containerColor : Color = AdaptiveTheme.colorScheme.surfaceVariant,
+    onDismissRequest: () -> Unit,
+    title: @Composable () -> Unit,
+    message: (@Composable () -> Unit)? = null,
+    containerColor: Color = AdaptiveTheme.colorScheme.tertiaryContainer,
     buttonsOrientation: Orientation = Orientation.Horizontal,
-    buttons : CupertinoAlertDialogButtonsScope.() -> Unit
+    buttons: CupertinoAlertDialogButtonsScope.() -> Unit
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoNavigationBar.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoNavigationBar.kt
@@ -67,7 +67,7 @@ fun CupertinoNavigationBar(
     withDivider : Boolean = !isTransparent(),
     content: @Composable RowScope.() -> Unit
 ) {
-    val background by remember {
+    val background by remember(containerColor) {
         derivedStateOf {
             if (isTransparent())
                 containerColor.copy(alpha = 0f) else containerColor

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoSegmentedControl.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoSegmentedControl.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -155,7 +154,7 @@ fun CupertinoSlidingSegmentedControl(
         .height(CupertinoSegmentedControlDefaults.minHeight),
     containerColor: Color = AppleColors.gray(isDark).copy(alpha = .25f),
     contentColor: Color = LocalTextStyle.current.color,
-    indicatorColor : Color = AdaptiveTheme.colorScheme.surfaceVariant,
+    indicatorColor: Color = AdaptiveTheme.colorScheme.secondaryContainer,
     indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = @Composable { tabPositions ->
         CupertinoSlidingSegmentedControlIndicator(
             selectedTabIndex = selectedTabIndex,
@@ -186,7 +185,6 @@ fun CupertinoSlidingSegmentedControlTab(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     title : @Composable () -> Unit,
 ) {
-    val color = LocalContentColor.current
     Box(
         modifier = modifier
             .clickable(
@@ -200,7 +198,7 @@ fun CupertinoSlidingSegmentedControlTab(
         CompositionLocalProvider(LocalTextStyle provides AdaptiveTheme.typography.labelLarge.copy(
             fontWeight = FontWeight.SemiBold,
             fontStyle = FontStyle.Normal,
-            color = if (isSelected) contentColorFor(color) else color,
+            color = AdaptiveTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center
         )) {
             title()

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoTopAppBars.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoTopAppBars.kt
@@ -158,7 +158,8 @@ fun CupertinoLargeTopAppBar(
         titleBottomPadding = 0.dp,
         smallTitle = title,
         smallTitleTextStyle = AdaptiveTheme.typography.bodyLarge.copy(
-            fontWeight = FontWeight.Bold
+            fontWeight = FontWeight.Bold,
+            color = AdaptiveTheme.colorScheme.onSurface
         ),
         navigationIcon = navigationIcon,
         actions = actions,

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoTopAppBars.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/components/cupertino/CupertinoTopAppBars.kt
@@ -2,64 +2,42 @@
 package com.github.alexzhirkevich.lookandfeel.components.cupertino
 
 import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDecay
-import androidx.compose.animation.core.animateTo
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
-import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TopAppBarState
-import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.listSaver
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.AlignmentLine
 import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.layout.Layout
@@ -70,14 +48,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.github.alexzhirkevich.lookandfeel.components.cupertino.modifiers.ScrollOverflowState
 import com.github.alexzhirkevich.lookandfeel.theme.AdaptiveTheme
 import com.github.alexzhirkevich.lookandfeel.util.statusBars
-import moe.tlaster.precompose.navigation.LocalSceneConfiguration
-import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -179,6 +153,7 @@ fun CupertinoLargeTopAppBar(
         titleOffset = titleOffset,
         titleTextStyle = AdaptiveTheme.typography.titleLarge.copy(
             fontWeight = FontWeight.Bold,
+            color = AdaptiveTheme.colorScheme.onBackground
         ),
         titleBottomPadding = 0.dp,
         smallTitle = title,

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/AppleColors.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/AppleColors.kt
@@ -70,4 +70,13 @@ object AppleColors {
     fun gray6(dark: Boolean) = if (dark)
         Color(28, 28, 30)
     else Color(242, 242, 247)
+
+    fun gray7(dark: Boolean) = if (dark)
+        Color(35, 35, 35)
+    else Color(238, 238, 238)
+
+    fun gray8(dark: Boolean) = if (dark)
+        Color(90, 90, 95)
+    else
+        Color(254, 254, 254)
 }

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/Theme.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/Theme.kt
@@ -21,29 +21,106 @@ data class ApplicationTheme(
 )
 
 fun Typography.cupertino() : Typography = copy(
-    displayLarge = titleLarge.copy(fontSize = 34.sp, lineHeight = 34.sp * 1.4f, fontWeight = FontWeight.Normal),
-    displayMedium = titleMedium.copy(fontSize = 28.sp, lineHeight = 28.sp * 1.4f, fontWeight = FontWeight.Normal),
-    displaySmall = titleSmall.copy(fontSize = 22.sp, lineHeight = 22.sp * 1.4f, fontWeight = FontWeight.Normal),
-    titleLarge = titleLarge.copy(fontSize = 34.sp, lineHeight = 34.sp * 1.4f, fontWeight = FontWeight.Normal),
-    titleMedium = titleMedium.copy(fontSize = 28.sp, lineHeight = 28.sp * 1.4f, fontWeight = FontWeight.Normal),
-    titleSmall = titleSmall.copy(fontSize = 22.sp, lineHeight = 22.sp * 1.4f, fontWeight = FontWeight.Normal),
-    headlineLarge = headlineLarge.copy(fontSize = 17.sp, lineHeight = 17.sp * 1.4f, fontWeight = FontWeight.SemiBold),
-    headlineMedium = headlineMedium.copy(fontSize = 16.sp, lineHeight = 16.sp * 1.4f, fontWeight = FontWeight.Normal),
-    headlineSmall = headlineSmall.copy(fontSize = 15.sp, lineHeight = 15.sp * 1.4f, fontWeight = FontWeight.Normal),
-    bodyLarge = bodyLarge.copy(fontSize = 17.sp, lineHeight = 19.sp * 1.4f, fontWeight = FontWeight.Normal),
-    bodyMedium = bodyMedium.copy(fontSize = 17.sp, lineHeight = 17.sp * 1.4f, fontWeight = FontWeight.Normal),
-    bodySmall = bodySmall.copy(fontSize = 15.sp, lineHeight = 15.sp * 1.4f, fontWeight = FontWeight.Normal),
-    labelLarge = labelLarge.copy(fontSize = 13.sp, lineHeight = 13.sp * 1.4f, fontWeight = FontWeight.Normal),
-    labelMedium = labelMedium.copy(fontSize = 12.sp, lineHeight = 12.sp * 1.4f, fontWeight = FontWeight.Normal),
-    labelSmall = labelSmall.copy(fontSize = 11.sp, lineHeight = 11.sp * 1.4f, fontWeight = FontWeight.Normal),
+    displayLarge = titleLarge.copy(
+        fontSize = 34.sp,
+        lineHeight = 34.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    displayMedium = titleMedium.copy(
+        fontSize = 28.sp,
+        lineHeight = 28.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    displaySmall = titleSmall.copy(
+        fontSize = 22.sp,
+        lineHeight = 22.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    titleLarge = titleLarge.copy(
+        fontSize = 34.sp,
+        lineHeight = 34.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    titleMedium = titleMedium.copy(
+        fontSize = 28.sp,
+        lineHeight = 28.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    titleSmall = titleSmall.copy(
+        fontSize = 22.sp,
+        lineHeight = 22.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    headlineLarge = headlineLarge.copy(
+        fontSize = 17.sp,
+        lineHeight = 17.sp * 1.4f,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = (-0.5).sp
+    ),
+    headlineMedium = headlineMedium.copy(
+        fontSize = 16.sp,
+        lineHeight = 16.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    headlineSmall = headlineSmall.copy(
+        fontSize = 15.sp,
+        lineHeight = 15.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    bodyLarge = bodyLarge.copy(
+        fontSize = 17.sp,
+        lineHeight = 19.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    bodyMedium = bodyMedium.copy(
+        fontSize = 17.sp,
+        lineHeight = 17.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    bodySmall = bodySmall.copy(
+        fontSize = 15.sp,
+        lineHeight = 15.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    labelLarge = labelLarge.copy(
+        fontSize = 13.sp,
+        lineHeight = 13.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    labelMedium = labelMedium.copy(
+        fontSize = 12.sp,
+        lineHeight = 12.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
+    labelSmall = labelSmall.copy(
+        fontSize = 11.sp,
+        lineHeight = 11.sp * 1.4f,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = (-0.5).sp
+    ),
 )
 
 fun ColorScheme.cupertino(dark : Boolean) : ColorScheme = copy(
-    background = if (dark) Color.Black else AppleColors.gray5(false),
-    surface = AppleColors.gray6(dark),
-    surfaceVariant = AppleColors.gray6(dark) ,
+    background = if (dark) Color.Black else AppleColors.gray6(false),
+    surface = if (dark) AppleColors.gray6(true) else Color.White,
+    surfaceVariant = if (dark) AppleColors.gray6(true) else Color.White,
     onSurfaceVariant = if (dark) Color.White else Color.Black,
     primaryContainer = AppleColors.gray5(dark),
+    secondaryContainer = AppleColors.gray8(dark), // Segmented control indicator
+    tertiaryContainer = AppleColors.gray7(dark), // Alert dialog
     error = AppleColors.red(dark),
     outlineVariant = AppleColors.gray(dark)
 //    outlineVariant = outlineVariant.copy(alpha = .75f)

--- a/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/Theme.kt
+++ b/lookandfeel/src/commonMain/kotlin/com/github/alexzhirkevich/lookandfeel/theme/Theme.kt
@@ -121,6 +121,7 @@ fun ColorScheme.cupertino(dark : Boolean) : ColorScheme = copy(
     primaryContainer = AppleColors.gray5(dark),
     secondaryContainer = AppleColors.gray8(dark), // Segmented control indicator
     tertiaryContainer = AppleColors.gray7(dark), // Alert dialog
+    onTertiaryContainer = if (dark) Color.White else Color.Black,
     error = AppleColors.red(dark),
     outlineVariant = AppleColors.gray(dark)
 //    outlineVariant = outlineVariant.copy(alpha = .75f)


### PR DESCRIPTION
This PR makes a number of changes to make the Cupertino Look-and-feel more aligned to the UIKit counterpart:

It changes the container colors to reflect the same combination of grays as they are used on iOS. It also introduces new gray tones for alerts and segmented controls for both light and dark mode.

It also fixes some of the issues in dark mode, such as not being able to see the text in the top application bar, or the large title not being visible on the dark background.

I've also made some changes to the typography: I've updated the project to 1.5.0-dev, which adds the iOS-native SF Pro font out of the box. iOS also changes the default letter-spacing for SF Pro text, so this PR adjusts that as well to give the text a similar condensed look as the rest of the system.

Comparison: iOS Settings / Recolor & Re-Typography / Original

<img width="1371" alt="Screenshot 2023-06-16 at 19 55 10" src="https://github.com/alexzhirkevich/compose-look-and-feel/assets/2178959/34d0bf7b-979d-4d7c-a0af-e10c5bbd25f8">
